### PR TITLE
fix: detect processes without path separators

### DIFF
--- a/src/process/index.ts
+++ b/src/process/index.ts
@@ -246,7 +246,7 @@ export default class ProcessServer {
 		const toCompare: string[] = [];
 		const splitPath = normalizedPath.split("/");
 
-		for (let i = 1; i < splitPath.length; i++) {
+		for (let i = 1; i <= splitPath.length; i++) {
 			toCompare.push(splitPath.slice(-i).join("/"));
 		}
 


### PR DESCRIPTION
Same fix as https://github.com/OpenAsar/arrpc/pull/165

Fixes detection when `/proc/*/cmdline` contains just the executable name without path separators.

The loop condition `i < splitPath.length` never executed when `splitPath.length === 1`, leaving `toCompare` empty. Changed to `i <= splitPath.length` so it runs at least once.